### PR TITLE
Added 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,41 @@ Some JVM performance benchmarks using JMH
 Currently the tests are :
 
 DynamicLanguages.groovy
+
 ExceptionsBenchMark.throwRuntimeException
+
 GeneratePoiWorkBook.generatePoiXLSWorkBook
+
 GeneratePoiWorkBook.generatePoiXLSXWorkBook
+
 GeneratePrimeNumbersWithForLoop.generatePrime
+
 Jackson.jsonMashal
+
 Jackson.jsonUnmashal
+
 Jackson.xmlMashalJackson
+
 Jackson.xmlMashalJacksonStatic
+
 Jackson.xmlUnmashalJackson
+
 Jackson.xmlUnmashalJacksonStatic
+
 JaxbMashalUnMashal.mashal
+
 JaxbMashalUnMashal.mashalStatic
+
 JaxbMashalUnMashal.unmashal
+
 JaxbMashalUnMashal.unmashalStatic
+
 Reflection.doReflection
+
 RegularExpressions.validateEmail
+
+#To Build
+mvn install
+
+#To run
+java -jar target/commonscenario-baseline-uber.jar

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <version>${jmh.version}</version>

--- a/src/main/java/com/github/vmbenchmarks/DynamicLanguages.java
+++ b/src/main/java/com/github/vmbenchmarks/DynamicLanguages.java
@@ -2,8 +2,6 @@ package com.github.vmbenchmarks;
 
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
-import java.io.BufferedReader;
-import java.io.StringReader;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class DynamicLanguages {

--- a/src/main/java/com/github/vmbenchmarks/GeneratePoiWorkBook.java
+++ b/src/main/java/com/github/vmbenchmarks/GeneratePoiWorkBook.java
@@ -1,18 +1,14 @@
 package com.github.vmbenchmarks;
 
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.openjdk.jmh.annotations.Benchmark;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import org.apache.poi.hssf.usermodel.HSSFWorkbook;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.CreationHelper;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.State;
 
 public class GeneratePoiWorkBook {
 

--- a/src/main/java/com/github/vmbenchmarks/Jackson.java
+++ b/src/main/java/com/github/vmbenchmarks/Jackson.java
@@ -3,13 +3,12 @@ package com.github.vmbenchmarks;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import static com.github.vmbenchmarks.JaxbMashalUnMashal.staticCounter;
-import java.io.File;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.openjdk.jmh.annotations.Benchmark;
 import com.github.vmbenchmarks.User.Name;
-import java.io.IOException;
+import org.openjdk.jmh.annotations.Benchmark;
+
 import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class Jackson {
 

--- a/src/main/java/com/github/vmbenchmarks/JaxbMashalUnMashal.java
+++ b/src/main/java/com/github/vmbenchmarks/JaxbMashalUnMashal.java
@@ -1,14 +1,15 @@
 package com.github.vmbenchmarks;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.util.concurrent.atomic.AtomicLong;
+import org.openjdk.jmh.annotations.Benchmark;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
-import org.openjdk.jmh.annotations.Benchmark;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class JaxbMashalUnMashal {
 

--- a/src/main/java/com/github/vmbenchmarks/MicroBenchMarks.java
+++ b/src/main/java/com/github/vmbenchmarks/MicroBenchMarks.java
@@ -1,9 +1,10 @@
 package com.github.vmbenchmarks;
 
+import org.openjdk.jmh.annotations.Benchmark;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import org.openjdk.jmh.annotations.Benchmark;
 
 public class MicroBenchMarks {
 

--- a/src/main/java/com/github/vmbenchmarks/RegularExpressions.java
+++ b/src/main/java/com/github/vmbenchmarks/RegularExpressions.java
@@ -1,9 +1,10 @@
 package com.github.vmbenchmarks;
 
+import org.openjdk.jmh.annotations.Benchmark;
+
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.openjdk.jmh.annotations.Benchmark;
 
 public class RegularExpressions {
 


### PR DESCRIPTION
Current version on Master branch, generate a compilation error with Java 9.

```
[ERROR] Annotation generator had thrown the exception. java.lang.NoClassDefFoundError: javax/annotation/Generated
[ERROR]         at org.openjdk.jmh.generators.core.BenchmarkGenerator.generateImport(BenchmarkGenerator.java:601)
```

To solve the issue, I had to add the following dependency to compile the project:

```
<dependency>
<groupId>javax.annotation</groupId>
<artifactId>javax.annotation-api</artifactId>
<version>1.3</version>
</dependency>
```